### PR TITLE
feat: Add module to support router by using GoRouter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,19 @@ A NestJS-inspired dependency injection framework for Dart, bringing modular arch
 - 💉 **Dependency Injection** - Type-safe service resolution with GetIt
 - 🔒 **Access Control** - Services are private by default, must be explicitly exported
 - 🔧 **Multi-Platform** - Works with Flutter, Dart Frog, and pure Dart applications
+- 🚦 **Module-Based Routing** - GoRouter integration with automatic route collection
 
 ## Packages
 
-- **nest_core** - Core dependency injection and module system
-- **nest_flutter** - Flutter integration with provider support
-- **nest_frog** - Dart Frog backend integration
+| Package | Version | Description |
+|---------|---------|-------------|
+| **[nest_core](packages/nest_core)** | ![pub version](https://img.shields.io/pub/v/nest_core.svg) | Core dependency injection and module system |
+| **[nest_flutter](packages/nest_flutter)** | ![pub version](https://img.shields.io/pub/v/nest_flutter.svg) | Flutter integration with GoRouter and provider support |
+| **[nest_frog](packages/nest_frog)** | ![pub version](https://img.shields.io/pub/v/nest_frog.svg) | Dart Frog backend integration with middleware support |
 
 ## Quick Start
+
+### Core Application
 
 ```dart
 import 'package:nest_core/nest_core.dart';
@@ -26,22 +31,79 @@ class AppModule extends Module {
   
   @override
   void providers(Locator locator) {
-    // Register your services here
+    locator.registerSingleton<UserService>(UserService());
   }
   
   @override
-  List<Type> get exports => []; // Export services to other modules
+  List<Type> get exports => [UserService];
 }
 
 // Initialize the application
-final container = ApplicationContainer(AppModule());
-await container.initialize();
+final container = ApplicationContainer();
+await container.registerModule(AppModule());
+```
+
+### Flutter Integration
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:nest_flutter/nest_flutter.dart';
+
+void main() {
+  runApp(
+    ModularApp(
+      module: AppModule(),
+      child: MyApp(),
+    ),
+  );
+}
+
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp.router(
+      routerConfig: Modular.router((router) {
+        return GoRouter(
+          routes: router.configuration.routes,
+          initialLocation: '/',
+        );
+      }),
+    );
+  }
+}
+```
+
+### Module with Routes
+
+```dart
+class UserModule extends Module {
+  @override
+  List<RouteBase> get routes => [
+    GoRoute(
+      path: '/users',
+      builder: (context, state) => UserListPage(),
+    ),
+  ];
+
+  @override
+  void providers(Locator locator) {
+    locator.registerSingleton<UserService>(UserService());
+  }
+}
 ```
 
 ## Examples
 
-- **Flutter App** - Mobile app with modular architecture
-- **Frog Backend** - REST API server with dependency injection
+- **[Flutter App](examples/flutter_app)** - Mobile app with modular architecture and GoRouter integration
+- **[Frog Backend](examples/frog_backend)** - REST API server with dependency injection and middleware
+
+## Documentation
+
+- 📖 **[Getting Started](https://khode-io.github.io/nest-dart/getting-started)** - Quick introduction to Nest Dart
+- 🎯 **[Core Guide](https://khode-io.github.io/nest-dart/core-guide)** - Dependency injection fundamentals
+- 📱 **[Flutter Guide](https://khode-io.github.io/nest-dart/flutter-guide)** - Flutter integration and routing
+- 🐸 **[Frog Guide](https://khode-io.github.io/nest-dart/frog-guide)** - Dart Frog backend development
+- 🔧 **[API Reference](https://khode-io.github.io/nest-dart/api-reference)** - Complete API documentation
 
 ## Development
 
@@ -55,3 +117,7 @@ melos run test
 # Format code
 melos run format
 ```
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/docs/pages/flutter-guide.mdx
+++ b/docs/pages/flutter-guide.mdx
@@ -14,7 +14,7 @@ Check [pub.dev](https://pub.dev) for the latest versions of Nest Dart packages b
 dependencies:
   flutter:
     sdk: flutter
-  nest_flutter: ^0.1.2
+  nest_flutter: ^0.1.3
 ```
 
 ## Quick Start
@@ -61,6 +61,42 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Nest Flutter Demo',
       home: HomePage(),
+    );
+  }
+}
+```
+
+### 2.1 With GoRouter Integration
+
+For apps using `go_router`, you can leverage the built-in routing integration:
+
+```dart
+// lib/main.dart
+import 'package:flutter/material.dart';
+import 'package:nest_flutter/nest_flutter.dart';
+import 'modules/app_module.dart';
+
+void main() {
+  runApp(
+    ModularApp(
+      module: AppModule(),
+      child: MyApp(),
+    ),
+  );
+}
+
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp.router(
+      title: 'Nest Flutter Demo',
+      routerConfig: Modular.router((router) {
+        return GoRouter(
+          routes: router.configuration.routes,
+          initialLocation: '/',
+          debugLogDiagnostics: true,
+        );
+      }),
     );
   }
 }
@@ -340,6 +376,193 @@ class CounterWidget extends StatelessWidget {
             ),
           ],
         );
+      },
+    );
+  }
+}
+```
+
+## Module-Based Routing
+
+The `nest_flutter` package provides powerful routing capabilities through `go_router` integration, allowing you to define routes directly in your modules.
+
+### Basic Module Routing
+
+Define routes in your modules using the `routes` getter:
+
+```dart
+// lib/modules/user_module.dart
+import 'package:nest_flutter/nest_flutter.dart';
+import '../pages/user_list_page.dart';
+import '../pages/user_detail_page.dart';
+
+class UserModule extends Module {
+  @override
+  List<RouteBase> get routes => [
+    GoRoute(
+      path: '/users',
+      builder: (context, state) => UserListPage(),
+      routes: [
+        GoRoute(
+          path: '/:id',
+          builder: (context, state) {
+            final userId = state.pathParameters['id']!;
+            return UserDetailPage(userId: userId);
+          },
+        ),
+      ],
+    ),
+  ];
+
+  @override
+  void providers(Locator locator) {
+    locator.registerSingleton<UserService>(UserService());
+  }
+}
+```
+
+### Route Prefixes
+
+Organize related routes under a common path prefix:
+
+```dart
+// lib/modules/admin_module.dart
+class AdminModule extends Module {
+  @override
+  String? get routePrefix => '/admin';
+
+  @override
+  List<RouteBase> get routes => [
+    GoRoute(
+      path: '/',
+      builder: (context, state) => AdminDashboard(),
+    ),
+    GoRoute(
+      path: '/users',
+      builder: (context, state) => AdminUsersPage(),
+    ),
+    GoRoute(
+      path: '/settings',
+      builder: (context, state) => AdminSettingsPage(),
+    ),
+  ];
+}
+```
+
+The routes above will be automatically prefixed:
+- `/admin/` → AdminDashboard
+- `/admin/users` → AdminUsersPage  
+- `/admin/settings` → AdminSettingsPage
+
+### Nested Module Routes
+
+Routes from imported modules are automatically collected:
+
+```dart
+class AppModule extends Module {
+  @override
+  List<Module> get imports => [
+    UserModule(),
+    AdminModule(),
+    ProductModule(),
+  ];
+
+  @override
+  List<RouteBase> get routes => [
+    GoRoute(
+      path: '/',
+      builder: (context, state) => HomePage(),
+    ),
+  ];
+}
+```
+
+All routes from `UserModule`, `AdminModule`, and `ProductModule` will be available in the app.
+
+### Router Configuration
+
+Use `Modular.router()` to create a configured router:
+
+```dart
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp.router(
+      routerConfig: Modular.router((router) {
+        return GoRouter(
+          routes: router.configuration.routes,
+          initialLocation: '/users',
+          debugLogDiagnostics: true,
+          redirect: (context, state) {
+            // Add authentication checks
+            final authService = Modular.get<AuthService>();
+            if (!authService.isAuthenticated && state.uri.path.startsWith('/admin')) {
+              return '/login';
+            }
+            return null;
+          },
+        );
+      }),
+    );
+  }
+}
+```
+
+### Router Caching and Performance
+
+The router is automatically cached to prevent recreation during hot reloads:
+
+```dart
+// Clear router cache when needed (useful for testing)
+Modular.clearRouterCache();
+
+// Check if router is cached
+if (Modular.isRouterCached) {
+  print('Router is cached');
+}
+
+// Force router recreation
+final router = Modular.router(
+  (router) => GoRouter(routes: router.configuration.routes),
+  forceRecreate: true,
+);
+```
+
+### Navigation with Services
+
+Combine routing with dependency injection:
+
+```dart
+class NavigationService {
+  void goToUserDetail(String userId) {
+    GoRouter.of(context).go('/users/$userId');
+  }
+  
+  void goToAdminPanel() {
+    GoRouter.of(context).go('/admin');
+  }
+}
+
+class UserModule extends Module {
+  @override
+  void providers(Locator locator) {
+    locator.registerSingleton<NavigationService>(NavigationService());
+  }
+}
+
+// Usage in widgets
+class UserTile extends StatelessWidget {
+  final User user;
+  
+  const UserTile({required this.user});
+  
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Text(user.name),
+      onTap: () {
+        final nav = Modular.get<NavigationService>();
+        nav.goToUserDetail(user.id);
       },
     );
   }
@@ -695,20 +918,23 @@ class UserServiceException implements Exception {
 }
 ```
 
-### 4. Navigation with Services
+### 4. Navigation with GoRouter Integration
 
-Integrate with Flutter navigation:
+With the new `go_router` integration, navigation becomes more powerful and type-safe:
 
 ```dart
 class NavigationService {
-  final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
-  
-  Future<T?> pushNamed<T>(String routeName, {Object? arguments}) {
-    return navigatorKey.currentState!.pushNamed<T>(routeName, arguments: arguments);
+  void goToUserDetail(String userId) {
+    // Use go_router's context-free navigation
+    GoRouter.of(navigatorKey.currentContext!).go('/users/$userId');
   }
   
-  void pop<T>([T? result]) {
-    navigatorKey.currentState!.pop<T>(result);
+  void goToAdminPanel() {
+    GoRouter.of(navigatorKey.currentContext!).go('/admin');
+  }
+  
+  void goBack() {
+    GoRouter.of(navigatorKey.currentContext!).pop();
   }
 }
 
@@ -717,20 +943,27 @@ class AppModule extends Module {
   void providers(Locator locator) {
     locator.registerSingleton<NavigationService>(NavigationService());
   }
+  
+  @override
+  List<RouteBase> get routes => [
+    GoRoute(
+      path: '/',
+      builder: (context, state) => HomePage(),
+    ),
+  ];
 }
 
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    final navigationService = Modular.get<NavigationService>();
-    
-    return MaterialApp(
-      navigatorKey: navigationService.navigatorKey,
-      routes: {
-        '/': (context) => HomePage(),
-        '/users': (context) => UserPage(),
-        '/profile': (context) => ProfilePage(),
-      },
+    return MaterialApp.router(
+      routerConfig: Modular.router((router) {
+        return GoRouter(
+          routes: router.configuration.routes,
+          initialLocation: '/',
+          debugLogDiagnostics: true,
+        );
+      }),
     );
   }
 }

--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -25,7 +25,7 @@ dependencies:
 dependencies:
   flutter:
     sdk: flutter
-  nest_flutter: ^0.1.2
+  nest_flutter: ^0.1.3
 ```
 
 ### For Dart Frog Backends

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -1,57 +1,19 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_app/modules/splash_module.dart';
+import 'package:flutter_app/modules/todo_module.dart';
 import 'package:nest_flutter/nest_flutter.dart';
 import 'package:provider/provider.dart' hide Locator;
-import 'package:shared_preferences/shared_preferences.dart';
-import 'services/todo_service.dart';
+import 'package:go_router/go_router.dart';
 import 'providers/todo_provider.dart';
-import 'views/todo_list_view.dart';
-import 'utils/config_preference.dart';
-import 'package:http/http.dart' show Client;
-
-class CoreModule extends Module {
-  @override
-  Future<void> providers(Locator locator) async {
-    locator.registerSingleton<Client>(Client());
-    final prefs = await SharedPreferences.getInstance();
-    locator.registerSingleton<SharedPreferences>(prefs);
-    locator.registerSingleton<ConfigPreference>(ConfigPreference(prefs));
-  }
-
-  @override
-  List<Type> get exports => [Client, SharedPreferences, ConfigPreference];
-}
-
-class TodoModule extends Module {
-  @override
-  List<Module> get imports => [CoreModule()];
-
-  @override
-  Future<void> providers(Locator locator) async {
-    locator.registerSingleton<TodoService>(
-      JsonPlaceholderTodoService(client: locator.get<Client>()),
-    );
-    locator.registerSingleton<TodoProvider>(
-      TodoProvider(locator.get<TodoService>(), locator.get<ConfigPreference>()),
-    );
-
-    locator.registerSingleton<ServiceDemo>(
-      ServiceDemo(locator.get<SharedPreferences>()),
-    );
-  }
-
-  @override
-  List<Type> get exports => [TodoService, TodoProvider];
-}
-
-class ServiceDemo {
-  final SharedPreferences prefs;
-
-  ServiceDemo(this.prefs);
-}
 
 class AppModule extends Module {
   @override
-  List<Module> get imports => [CoreModule(), TodoModule()];
+  List<Module> get imports => [
+    SplashModule(),
+    TodoModule(),
+    ModuleA(),
+    ModuleB(),
+  ];
 
   @override
   Future<void> providers(Locator _) async {}
@@ -59,19 +21,7 @@ class AppModule extends Module {
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
-  runApp(
-    ModularApp(
-      module: AppModule(),
-      loading: MaterialApp(
-        theme: ThemeData(
-          colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-          useMaterial3: true,
-        ),
-        home: const Scaffold(body: Center(child: CircularProgressIndicator())),
-      ),
-      child: const MainApp(),
-    ),
-  );
+  runApp(ModularApp(module: AppModule(), child: const MainApp()));
 }
 
 class MainApp extends StatelessWidget {
@@ -81,13 +31,14 @@ class MainApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return ChangeNotifierProvider(
       create: (context) => Modular.get<TodoProvider>(),
-      child: MaterialApp(
-        title: 'Todo App',
-        theme: ThemeData(
-          colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-          useMaterial3: true,
-        ),
-        home: const TodoListView(),
+      child: MaterialApp.router(
+        routerConfig: Modular.router((router) {
+          return GoRouter(
+            routes: router.configuration.routes,
+            initialLocation: '/todos',
+            debugLogDiagnostics: true,
+          );
+        }),
       ),
     );
   }

--- a/examples/flutter_app/lib/modules/core_module.dart
+++ b/examples/flutter_app/lib/modules/core_module.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_app/utils/config_preference.dart';
+import 'package:nest_flutter/nest_flutter.dart';
+import 'package:http/http.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class CoreModule extends Module {
+  @override
+  Future<void> providers(Locator locator) async {
+    locator.registerSingleton<Client>(Client());
+    final prefs = await SharedPreferences.getInstance();
+    locator.registerSingleton<SharedPreferences>(prefs);
+    locator.registerSingleton<ConfigPreference>(ConfigPreference(prefs));
+  }
+
+  @override
+  List<Type> get exports => [Client, SharedPreferences, ConfigPreference];
+}

--- a/examples/flutter_app/lib/modules/splash_module.dart
+++ b/examples/flutter_app/lib/modules/splash_module.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nest_flutter/nest_flutter.dart';
+
+class SplashModule extends Module {
+  @override
+  List<RouteBase> get routes => [
+    GoRoute(path: '/', builder: (context, state) => const SplashView()),
+  ];
+}
+
+class SplashView extends StatelessWidget {
+  const SplashView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(body: Center(child: CircularProgressIndicator()));
+  }
+}

--- a/examples/flutter_app/lib/modules/todo_module.dart
+++ b/examples/flutter_app/lib/modules/todo_module.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_app/modules/core_module.dart';
+import 'package:flutter_app/services/todo_service.dart';
+import 'package:flutter_app/providers/todo_provider.dart';
+import 'package:flutter_app/utils/config_preference.dart';
+import 'package:flutter_app/views/todo_list_view.dart';
+import 'package:flutter_app/views/todo_detail_view.dart';
+import 'package:nest_flutter/nest_flutter.dart';
+import 'package:http/http.dart';
+
+class ModuleB extends Module {
+  @override
+  String? get routePrefix => '/module-b';
+
+  @override
+  List<RouteBase> get routes => [
+    GoRoute(
+      path: '/',
+      builder: (context, state) => const Placeholder(),
+      routes: [
+        GoRoute(
+          path: 'second',
+          builder: (context, state) => const Placeholder(),
+        ),
+      ],
+    ),
+  ];
+}
+
+class ModuleA extends Module {
+  @override
+  String? get routePrefix => '/module-a';
+
+  @override
+  List<RouteBase> get routes => [
+    GoRoute(path: '/', builder: (context, state) => const Placeholder()),
+  ];
+}
+
+class TodoModule extends Module {
+  @override
+  List<Module> get imports => [CoreModule()];
+
+  @override
+  Future<void> providers(Locator locator) async {
+    locator.registerSingleton<TodoService>(
+      JsonPlaceholderTodoService(client: locator.get<Client>()),
+    );
+    locator.registerSingleton<TodoProvider>(
+      TodoProvider(locator.get<TodoService>(), locator.get<ConfigPreference>()),
+    );
+  }
+
+  @override
+  List<Type> get exports => [TodoService, TodoProvider];
+
+  @override
+  String? get routePrefix => '/todos';
+
+  @override
+  List<RouteBase> get routes => [
+    GoRoute(path: '/', builder: (context, state) => const TodoListView()),
+    GoRoute(
+      path: '/:id',
+      builder: (context, state) => TodoDetailView(
+        todoId: int.tryParse(state.pathParameters['id'] ?? '0') ?? 0,
+      ),
+    ),
+    GoRoute(path: '/second', builder: (context, state) => Placeholder()),
+  ];
+}

--- a/examples/flutter_app/lib/services/todo_service.dart
+++ b/examples/flutter_app/lib/services/todo_service.dart
@@ -16,6 +16,7 @@ class JsonPlaceholderTodoService implements TodoService {
 
   @override
   Future<List<Todo>> getAllTodos() async {
+    await Future.delayed(const Duration(seconds: 2));
     try {
       final response = await _client.get(
         Uri.parse('$_baseUrl/todos'),

--- a/examples/flutter_app/lib/views/todo_list_view.dart
+++ b/examples/flutter_app/lib/views/todo_list_view.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import '../models/todo.dart';
 import '../providers/todo_provider.dart';
-import 'todo_detail_view.dart';
 
 class TodoListView extends StatefulWidget {
   const TodoListView({super.key});
@@ -94,19 +94,6 @@ class _TodoListViewState extends State<TodoListView> {
       );
     }
 
-    if (todoProvider.todos.isEmpty) {
-      return const Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(Icons.inbox_outlined, size: 64, color: Colors.grey),
-            SizedBox(height: 16),
-            Text('No todos found'),
-          ],
-        ),
-      );
-    }
-
     return RefreshIndicator(
       onRefresh: () => todoProvider.refreshTodos(),
       child: ListView.builder(
@@ -151,9 +138,7 @@ class _TodoListViewState extends State<TodoListView> {
   }
 
   void _navigateToTodoDetail(int todoId) {
-    Navigator.of(context).push(
-      MaterialPageRoute(builder: (context) => TodoDetailView(todoId: todoId)),
-    );
+    context.push('/todos/$todoId');
   }
 
   void _showTodoByIdDialog() {

--- a/examples/flutter_app/pubspec.lock
+++ b/examples/flutter_app/pubspec.lock
@@ -96,6 +96,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.1.0"
+  go_router:
+    dependency: transitive
+    description:
+      name: go_router
+      sha256: c489908a54ce2131f1d1b7cc631af9c1a06fac5ca7c449e959192089f9489431
+      url: "https://pub.dev"
+    source: hosted
+    version: "16.0.0"
   http:
     dependency: "direct main"
     description:
@@ -152,6 +160,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.6.1"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:
@@ -189,7 +205,7 @@ packages:
       path: "../../packages/nest_flutter"
       relative: true
     source: path
-    version: "0.1.1"
+    version: "0.1.2"
   nested:
     dependency: transitive
     description:

--- a/examples/flutter_app/pubspec.yaml
+++ b/examples/flutter_app/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
     path: ../../packages/nest_flutter
   http: any
   provider: any
-  shared_preferences: any    
+  shared_preferences: any
 
 dev_dependencies:
   flutter_test:

--- a/packages/nest_core/README.md
+++ b/packages/nest_core/README.md
@@ -164,9 +164,9 @@ class DatabaseModule extends Module {
 
 ## Documentation
 
-- [Getting Started Guide](https://chornthorn.github.io/nest-dart/getting-started)
-- [API Reference](https://chornthorn.github.io/nest-dart/api-reference)
-- [Examples](https://chornthorn.github.io/nest-dart/examples)
+- [Getting Started Guide](https://khode-io.github.io/nest-dart/getting-started)
+- [API Reference](https://khode-io.github.io/nest-dart/api-reference)
+- [Examples](https://khode-io.github.io/nest-dart/examples)
 
 ## Contributing
 

--- a/packages/nest_core/pubspec.yaml
+++ b/packages/nest_core/pubspec.yaml
@@ -2,10 +2,10 @@ name: nest_core
 description: Core dependency injection and module system for Nest Dart - a NestJS-inspired framework for building modular Dart applications.
 version: 0.1.1
 resolution: workspace
-homepage: https://chornthorn.github.io/nest-dart
-repository: https://github.com/chornthorn/nest-dart
-issue_tracker: https://github.com/chornthorn/nest-dart/issues
-documentation: https://chornthorn.github.io/nest-dart/core-guide
+homepage: https://khode-io.github.io/nest-dart
+repository: https://github.com/khode-io/nest-dart
+issue_tracker: https://github.com/khode-io/nest-dart/issues
+documentation: https://khode-io.github.io/nest-dart/core-guide
 
 environment:
   sdk: ^3.8.1

--- a/packages/nest_flutter/CHANGELOG.md
+++ b/packages/nest_flutter/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to the `nest_flutter` package will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] - 2025-08-03
+
+### Added
+- **🚦 GoRouter Integration** - Full integration with go_router for modern Flutter navigation
+- **📍 Module-based Routing** - Define routes directly in modules using the `routes` getter
+- **🔗 Route Prefixes** - Organize routes with automatic path prefixing using `routePrefix`
+- **🔄 Automatic Route Collection** - Routes from imported modules are automatically collected
+- **🎯 Modular.router()** - New static method to create configured GoRouter instances
+
+### Router API
+- `Modular.router(configurator)` - Create configured router from modules
+
+### Integration
+- **go_router dependency** - Added go_router as a direct dependency
+- **MaterialApp.router support** - Full integration with MaterialApp.router
+
 ## [0.1.2] - 2025-08-02
 
 ### Added

--- a/packages/nest_flutter/README.md
+++ b/packages/nest_flutter/README.md
@@ -9,16 +9,17 @@ Flutter integration for Nest Dart - bringing dependency injection and modular ar
 - 📱 **Reactive Services** - ChangeNotifier support for state management
 - 🎨 **Context Access** - Get services from BuildContext
 - ⚡ **Static API** - Global service access with Modular class
+- 🚦 **Modular Routing** - go_router integration with module-based route organization
+- 🔗 **Route Prefixes** - Organize routes with automatic path prefixing
 
 ## Installation
 
 Add `nest_flutter` to your `pubspec.yaml`:
-
 ```yaml
 dependencies:
   flutter:
     sdk: flutter
-  nest_flutter: ^0.1.2
+  nest_flutter: ^0.1.3
 ```
 
 ## Quick Start
@@ -36,10 +37,24 @@ class AppModule extends Module {
   
   @override
   List<Type> get exports => [UserService];
+  
+  @override
+  List<RouteBase> get routes => [
+    GoRoute(
+      path: '/',
+      builder: (context, state) => HomePage(),
+    ),
+    GoRoute(
+      path: '/users/:id',
+      builder: (context, state) => UserDetailPage(
+        userId: state.pathParameters['id']!,
+      ),
+    ),
+  ];
 }
 ```
 
-### 2. Wrap Your App
+### 2. Setup Your App with Router
 
 ```dart
 import 'package:flutter/material.dart';
@@ -57,9 +72,14 @@ void main() {
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return MaterialApp.router(
       title: 'Nest Flutter Demo',
-      home: HomePage(),
+      routerConfig: Modular.router((router) {
+        return GoRouter(
+          routes: router.configuration.routes,
+          initialLocation: '/',
+        );
+      }),
     );
   }
 }
@@ -92,7 +112,10 @@ class _HomePageState extends State<HomePage> {
           if (snapshot.hasData) {
             return ListView(
               children: snapshot.data!
-                  .map((user) => ListTile(title: Text(user.name)))
+                  .map((user) => ListTile(
+                    title: Text(user.name),
+                    onTap: () => context.go('/users/${user.id}'),
+                  ))
                   .toList(),
             );
           }
@@ -231,9 +254,9 @@ class TestModule extends Module {
 
 ## Documentation
 
-- [Flutter Integration Guide](https://chornthorn.github.io/nest-dart/flutter-guide)
-- [API Reference](https://chornthorn.github.io/nest-dart/api-reference)
-- [Examples](https://chornthorn.github.io/nest-dart/examples)
+- [Flutter Integration Guide](https://khode-io.github.io/nest-dart/flutter-guide)
+- [API Reference](https://khode-io.github.io/nest-dart/api-reference)
+- [Examples](https://khode-io.github.io/nest-dart/examples)
 
 ## Related Packages
 

--- a/packages/nest_flutter/lib/nest_flutter.dart
+++ b/packages/nest_flutter/lib/nest_flutter.dart
@@ -5,7 +5,8 @@
 library;
 
 // Re-export nest_core for convenience
-export 'package:nest_core/nest_core.dart';
+export 'package:nest_core/nest_core.dart' hide Module;
+export 'package:go_router/go_router.dart';
 
 // Export Flutter-specific functionality
 export 'src/core.dart';

--- a/packages/nest_flutter/lib/src/container_provider.dart
+++ b/packages/nest_flutter/lib/src/container_provider.dart
@@ -2,42 +2,42 @@ part of 'core.dart';
 
 /// A ChangeNotifier wrapper for ApplicationContainer to enable reactive updates
 class ApplicationContainerNotifier extends ChangeNotifier {
-  final ApplicationContainer _container;
+  final nest_core.ApplicationContainer _container;
 
-  ApplicationContainerNotifier([ApplicationContainer? container])
-    : _container = container ?? ApplicationContainer();
+  ApplicationContainerNotifier([nest_core.ApplicationContainer? container])
+    : _container = container ?? nest_core.ApplicationContainer();
 
   /// Create with initial modules
   ApplicationContainerNotifier.withModules(
-    List<Module> modules, [
-    ApplicationContainer? container,
-  ]) : _container = container ?? ApplicationContainer() {
+    List<nest_core.Module> modules, [
+    nest_core.ApplicationContainer? container,
+  ]) : _container = container ?? nest_core.ApplicationContainer() {
     for (final module in modules) {
       _container.registerModule(module);
     }
   }
 
   /// Get the underlying container
-  ApplicationContainer get container => _container;
+  nest_core.ApplicationContainer get container => _container;
 
   /// Register a module (typically done during initialization)
-  void registerModule(Module module) {
+  void registerModule(nest_core.Module module) {
     _container.registerModule(module);
   }
 
   /// Register multiple modules (typically done during initialization)
-  void registerModules(List<Module> modules) {
+  void registerModules(List<nest_core.Module> modules) {
     _container.registerModules(modules);
   }
 
   /// Register a module and notify listeners (use for dynamic module registration)
-  void registerModuleWithNotification(Module module) {
+  void registerModuleWithNotification(nest_core.Module module) {
     _container.registerModule(module);
     notifyListeners();
   }
 
   /// Register multiple modules and notify listeners (use for dynamic module registration)
-  void registerModulesWithNotification(List<Module> modules) {
+  void registerModulesWithNotification(List<nest_core.Module> modules) {
     _container.registerModules(modules);
     notifyListeners();
   }
@@ -74,13 +74,13 @@ class ApplicationContainerNotifier extends ChangeNotifier {
   }
 
   /// Get all registered modules
-  List<Module> get modules => _container.modules;
+  List<nest_core.Module> get modules => _container.modules;
 
   /// Get the underlying GetIt instance (use with caution)
-  GetIt get getIt => _container.getIt;
+  nest_core.GetIt get getIt => _container.getIt;
 
   /// Get the module context (useful for testing and debugging)
-  ModuleContext get context => _container.context;
+  nest_core.ModuleContext get context => _container.context;
 }
 
 /// InheritedNotifier that provides ApplicationContainer to the widget tree
@@ -95,15 +95,15 @@ class ApplicationContainerProvider
   /// Create a provider with a new container
   ApplicationContainerProvider.create({
     super.key,
-    ApplicationContainer? container,
+    nest_core.ApplicationContainer? container,
     required super.child,
   }) : super(notifier: ApplicationContainerNotifier(container));
 
   /// Create a provider with initial modules
   ApplicationContainerProvider.withModules({
     super.key,
-    required List<Module> modules,
-    ApplicationContainer? container,
+    required List<nest_core.Module> modules,
+    nest_core.ApplicationContainer? container,
     required super.child,
   }) : super(
          notifier: ApplicationContainerNotifier.withModules(modules, container),
@@ -135,12 +135,14 @@ class ApplicationContainerProvider
   }
 
   /// Get the ApplicationContainer from the widget tree
-  static ApplicationContainer containerOf(BuildContext context) {
+  static nest_core.ApplicationContainer containerOf(BuildContext context) {
     return of(context).container;
   }
 
   /// Get the ApplicationContainer from the widget tree, or null if not found
-  static ApplicationContainer? maybeContainerOf(BuildContext context) {
+  static nest_core.ApplicationContainer? maybeContainerOf(
+    BuildContext context,
+  ) {
     return maybeOf(context)?.container;
   }
 }

--- a/packages/nest_flutter/lib/src/core.dart
+++ b/packages/nest_flutter/lib/src/core.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:nest_core/nest_core.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nest_core/nest_core.dart' as nest_core;
 
 part 'container_provider.dart';
 part 'modular.dart';
+part 'module.dart';

--- a/packages/nest_flutter/lib/src/module.dart
+++ b/packages/nest_flutter/lib/src/module.dart
@@ -1,0 +1,80 @@
+part of 'core.dart';
+
+/// Mixin that adds route support to nest_core Module
+mixin RouteMixin on nest_core.Module {
+  /// List of routes provided by this module
+  /// These routes will be automatically collected and registered with go_router
+  List<RouteBase> get routes => [];
+
+  /// Optional route prefix for this module's routes
+  /// Useful for organizing routes under a common path segment
+  String? get routePrefix => null;
+
+  /// Collect all routes from this module and its imports recursively
+  /// Prevents duplicate processing of the same module types
+  List<RouteBase> collectAllRoutes([Set<Type>? processedModuleTypes]) {
+    processedModuleTypes ??= <Type>{};
+    final allRoutes = <RouteBase>[];
+
+    // Skip if this module type has already been processed
+    if (processedModuleTypes.contains(runtimeType)) {
+      return allRoutes; // Return empty list for duplicate module types
+    }
+
+    // Mark this module type as processed
+    processedModuleTypes.add(runtimeType);
+
+    // First, collect routes from imported modules
+    for (final importedModule in imports) {
+      if (importedModule is Module) {
+        allRoutes.addAll(importedModule.collectAllRoutes(processedModuleTypes));
+      }
+    }
+
+    // Then add this module's routes, applying prefix if specified
+    for (final route in routes) {
+      // Apply route prefix if specified
+      final processedRoute = (routePrefix != null && routePrefix!.isNotEmpty)
+          ? _applyRoutePrefix(route, routePrefix!)
+          : route;
+
+      allRoutes.add(processedRoute);
+    }
+
+    return allRoutes;
+  }
+
+  /// Apply route prefix to a route
+  RouteBase _applyRoutePrefix(RouteBase route, String prefix) {
+    if (route is GoRoute) {
+      // Ensure prefix starts with / and doesn't end with /
+      final cleanPrefix = prefix.startsWith('/') ? prefix : '/$prefix';
+      final finalPrefix = cleanPrefix.endsWith('/')
+          ? cleanPrefix.substring(0, cleanPrefix.length - 1)
+          : cleanPrefix;
+
+      // Ensure route path starts with /
+      final routePath = route.path.startsWith('/')
+          ? route.path
+          : '/${route.path}';
+
+      // Combine prefix and path, avoiding double slashes
+      final newPath = routePath == '/' ? finalPrefix : '$finalPrefix$routePath';
+
+      return GoRoute(
+        path: newPath,
+        name: route.name,
+        builder: route.builder,
+        pageBuilder: route.pageBuilder,
+        redirect: route.redirect,
+        routes: route.routes,
+      );
+    }
+
+    // For other route types, return as-is
+    return route;
+  }
+}
+
+/// The Module class that extends nest_core Module with route support
+abstract class Module extends nest_core.Module with RouteMixin {}

--- a/packages/nest_flutter/pubspec.yaml
+++ b/packages/nest_flutter/pubspec.yaml
@@ -1,11 +1,11 @@
 name: nest_flutter
 description: Flutter integration for Nest Dart - bringing dependency injection and modular architecture to Flutter applications.
-version: 0.1.2
+version: 0.1.3
 resolution: workspace
-homepage: https://chornthorn.github.io/nest-dart
-repository: https://github.com/chornthorn/nest-dart
-issue_tracker: https://github.com/chornthorn/nest-dart/issues
-documentation: https://chornthorn.github.io/nest-dart/flutter-guide
+homepage: https://khode-io.github.io/nest-dart
+repository: https://github.com/khode-io/nest-dart
+issue_tracker: https://github.com/khode-io/nest-dart/issues
+documentation: https://khode-io.github.io/nest-dart/flutter-guide
 
 environment:
   sdk: ^3.8.1

--- a/packages/nest_flutter/pubspec.yaml
+++ b/packages/nest_flutter/pubspec.yaml
@@ -14,10 +14,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  # nest_core: ^0.1.1
+  nest_core: ^0.1.1
   go_router: any
-  nest_core:
-    path: ../../packages/nest_core
+  # nest_core:
+  #   path: ../../packages/nest_core
 
 dev_dependencies:
   lints: ^5.0.0

--- a/packages/nest_flutter/pubspec.yaml
+++ b/packages/nest_flutter/pubspec.yaml
@@ -14,7 +14,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  nest_core: ^0.1.1
+  # nest_core: ^0.1.1
+  go_router: any
+  nest_core:
+    path: ../../packages/nest_core
 
 dev_dependencies:
   lints: ^5.0.0

--- a/packages/nest_frog/README.md
+++ b/packages/nest_frog/README.md
@@ -275,9 +275,9 @@ class TestModule extends Module {
 
 ## Documentation
 
-- [Dart Frog Integration Guide](https://chornthorn.github.io/nest-dart/frog-guide)
-- [API Reference](https://chornthorn.github.io/nest-dart/api-reference)
-- [Examples](https://chornthorn.github.io/nest-dart/examples)
+- [Dart Frog Integration Guide](https://khode-io.github.io/nest-dart/frog-guide)
+- [API Reference](https://khode-io.github.io/nest-dart/api-reference)
+- [Examples](https://khode-io.github.io/nest-dart/examples)
 
 ## Related Packages
 

--- a/packages/nest_frog/pubspec.yaml
+++ b/packages/nest_frog/pubspec.yaml
@@ -2,10 +2,10 @@ name: nest_frog
 description: Dart Frog integration for Nest Dart - bringing dependency injection and modular architecture to Dart Frog backend applications.
 version: 0.1.2
 resolution: workspace
-homepage: https://chornthorn.github.io/nest-dart
-repository: https://github.com/chornthorn/nest-dart
-issue_tracker: https://github.com/chornthorn/nest-dart/issues
-documentation: https://chornthorn.github.io/nest-dart/frog-guide
+homepage: https://khode-io.github.io/nest-dart
+repository: https://github.com/khode-io/nest-dart
+issue_tracker: https://github.com/khode-io/nest-dart/issues
+documentation: https://khode-io.github.io/nest-dart/frog-guide
 
 environment:
   sdk: ^3.8.1

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -158,6 +158,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -182,6 +187,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  go_router:
+    dependency: transitive
+    description:
+      name: go_router
+      sha256: c489908a54ce2131f1d1b7cc631af9c1a06fac5ca7c449e959192089f9489431
+      url: "https://pub.dev"
+    source: hosted
+    version: "16.0.0"
   graphs:
     dependency: transitive
     description:
@@ -621,3 +634,4 @@ packages:
     version: "2.2.2"
 sdks:
   dart: ">=3.8.1 <4.0.0"
+  flutter: ">=3.27.0"


### PR DESCRIPTION
docs(nest_flutter): Add comprehensive router support documentation

- Add modular routing section with go_router integration
- Include route prefixes, nested routes, and navigation examples
- Show module-based route organization patterns
- Add router testing examples and best practices
- Update Quick Start to demonstrate router usage from the beginning